### PR TITLE
Fix possible Exceptions when closing PACTware project

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -181,7 +181,7 @@ Task("WiXCandle")
         NoLogo = true,
         Defines = new Dictionary<string, string> 
         {
-            { "Version", gitVersion.SemVer },
+            { "Version", gitVersion.MajorMinorPatch },
             { "SourceDir", "./src/Wetcon.PactwarePlugin.OpcUaServer.Setup/" }
         }
     });


### PR DESCRIPTION
Fix exceptions that may have occurred when closing the PACTware project after using KSB's automatic device scan with multiple COM Ports.

Changes in this PR:
* `DtmInterface<T>` could release the object pointer more than once.
* Device nodes could be re-added on project node removal.